### PR TITLE
Added features that require a user to select an account type at signu…

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -16,6 +16,11 @@ module.exports = function(sequelize, DataTypes) {
     password: {
       type: DataTypes.STRING,
       allowNull: false
+    },
+    // User type is either brewR or brewRy
+    usertype: {
+      type: DataTypes.STRING,
+      allowNull: false
     }
   });
   // Creating a custom method for our User model. This will check if an unhashed password entered by the user can be compared to the hashed password stored in our database

--- a/public/js/signup.js
+++ b/public/js/signup.js
@@ -9,27 +9,37 @@ $(document).ready(() => {
     event.preventDefault();
     const userData = {
       email: emailInput.val().trim(),
-      password: passwordInput.val().trim()
+      password: passwordInput.val().trim(),
+      usertype: $("input[name=signUpUserType]:checked", ".signUpUserType").val()
     };
 
     if (!userData.email || !userData.password) {
       return;
     }
     // If we have an email and password, run the signUpUser function
-    signUpUser(userData.email, userData.password);
+    signUpUser(userData.email, userData.password, userData.usertype);
     emailInput.val("");
     passwordInput.val("");
   });
 
   // Does a post to the signup route. If successful, we are redirected to the members page
   // Otherwise we log any errors
-  function signUpUser(email, password) {
+  function signUpUser(email, password, usertype) {
     $.post("/api/signup", {
       email: email,
-      password: password
+      password: password,
+      usertype: usertype
     })
-      .then(() => {
-        window.location.replace("/members");
+      .then((userInfo) => {
+        //  if user is a brewery then go to /brewer-page
+        let isABrewery = (userInfo.usertype === "brewRy");
+        if(isABrewery) {
+          window.location.replace("/brewer-page")
+        }
+        //  else direct user to /members
+        else {
+          window.location.replace("/members");
+        }
         // If there's an error, handle it by throwing up a bootstrap alert
       })
       .catch(handleLoginErr);

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,4 +1,6 @@
-form.signup,
+form.signup {
+  margin-top: 30px;
+}
 form.login {
   margin-top: 50px;
 }
@@ -24,4 +26,8 @@ h2 {
 
 .searchBtn {
   display: inline;
+}
+
+.signUpUserType {
+  margin-top: 30px;
 }

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -12,7 +12,8 @@ module.exports = function(app) {
     // Sending back a password, even a hashed password, isn't a good idea
     res.json({
       email: req.user.email,
-      id: req.user.id
+      id: req.user.id,
+      usertype: req.user.usertype
     });
   });
 
@@ -22,7 +23,8 @@ module.exports = function(app) {
   app.post("/api/signup", (req, res) => {
     db.User.create({
       email: req.body.email,
-      password: req.body.password
+      password: req.body.password,
+      usertype: req.body.usertype
     })
       .then(() => {
         res.redirect(307, "/api/login");

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -36,14 +36,14 @@ module.exports = function(app) {
   app.get("/member-feed", (req, res) => {
     console.log("success");
     db.Post.findAll({}).then(data => {
-      console.log(data);
+      console.log(data, "39");
       const x = data.map(packet => packet.dataValues.body);
-      console.log(x);
+      console.log(x, "41");
       obj = [];
       for (message of x) {
         obj.push({ body: message });
       }
-      console.log(obj);
+      console.log(obj, "46");
       res.render("member-feed", { Post: obj });
     });
   });
@@ -51,26 +51,26 @@ module.exports = function(app) {
   // members page blog route (this is the users profile page)
   app.get("/members", (req, res) => {
     db.Post.findAll({}).then(data => {
-      console.log(data);
+      console.log(data, "54");
       const x = data.map(packet => packet.dataValues.body);
-      console.log(x);
+      console.log(x, "56");
       obj = [];
       for (message of x) {
         obj.push({ body: message });
       }
-      console.log(obj);
+      console.log(obj, "61");
       res.render("member-feed", { Post: obj });
       res.render("members", { Post: obj });
     });
   });
 
   // brewer page
-  app.get("/brewer-page", (req, res) => {
+  app.get("/brewer-page", isAuthenticated, (req, res) => {
     res.render("brewer-page");
   });
 
   // brewer feed
-  app.get("/brewer-feed", (req, res) => {
+  app.get("/brewer-feed", isAuthenticated, (req, res) => {
     res.render("brewer-feed");
   });
 

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -1,28 +1,28 @@
 <nav class="navbar navbar-default">
-    <div class="container-fluid">
-        <div class="navbar-header">
-        </div>
+  <div class="container-fluid">
+    <div class="navbar-header">
     </div>
+  </div>
 </nav>
 <div class="container">
-    <div class="row">
-        <img class="col-md-4 img center-block lightbeermug" src="stylesheets/assets/lightmugbig.png"
-            alt="Light beer mug icon.">
-        <div class="col-md-4 col-md-offset-1">
-            <h2>brewR Login</h2>
-            <form class="login">
-                <div class="form-group">
-                    <label for="exampleInputEmail1">Email address</label>
-                    <input type="email" class="form-control" id="email-input" placeholder="Email">
-                </div>
-                <div class="form-group">
-                    <label for="exampleInputPassword1">Password</label>
-                    <input type="password" class="form-control" id="password-input" placeholder="Password">
-                </div>
-                <button type="submit" class="btn btn-default">Login</button>
-            </form>
-            <br />
-            <p><a href="/signup">Create Account</a></p>
+  <div class="row">
+    <img class="col-md-4 img center-block lightbeermug" src="stylesheets/assets/lightmugbig.png"
+      alt="Light beer mug icon.">
+    <div class="col-md-4 col-md-offset-1">
+      <h2>brewR Login</h2>
+      <form class="login">
+        <div class="form-group" id="emailForm">
+          <label for="exampleInputEmail1">Email address</label>
+          <input type="email" class="form-control" id="email-input" placeholder="Email">
         </div>
+        <div class="form-group">
+          <label for="exampleInputPassword1">Password</label>
+          <input type="password" class="form-control" id="password-input" placeholder="Password">
+        </div>
+        <button type="submit" class="btn btn-default">Login</button>
+      </form>
+      <br />
+      <p><a href="/signup">Create Account</a></p>
     </div>
+  </div>
 </div>

--- a/views/signup.handlebars
+++ b/views/signup.handlebars
@@ -1,32 +1,49 @@
 <nav class="navbar navbar-default">
-    <div class="container-fluid">
-        <div class="navbar-header">
-        </div>
+  <div class="container-fluid">
+    <div class="navbar-header">
     </div>
+  </div>
 </nav>
 <div class="container">
-    <div class="row">
-        <img class="col-md-4 img center-block lightbeermug" src="stylesheets/assets/lightmugbig.png"
-            alt="Light beer mug icon.">
-        <div class="col-md-4 col-md-offset-1">
-            <h2>brewR Sign Up</h2>
-            <form class="signup">
-                <div class="form-group">
-                    <label for="exampleInputEmail1">Email address</label>
-                    <input type="email" class="form-control" id="email-input" placeholder="Email">
-                </div>
-                <div class="form-group">
-                    <label for="exampleInputPassword1">Password</label>
-                    <input type="password" class="form-control" id="password-input" placeholder="Password">
-                </div>
-                <div style="display: none" id="alert" class="alert alert-danger" role="alert">
-                    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                    <span class="sr-only">Error:</span> <span class="msg"></span>
-                </div>
-                <button type="submit" class="btn btn-default">Sign Up</button>
-            </form>
-            <br />
-            <p>Or log in <a href="/">here</a></p>
+  <div class="row">
+    <img class="col-md-4 img center-block lightbeermug" src="stylesheets/assets/lightmugbig.png"
+      alt="Light beer mug icon.">
+    <div class="col-md-4 col-md-offset-1">
+      <h2>brewR Sign Up</h2>
+      <form class="signUpUserType">
+        <!-- This radio, if selected registers a user as a brewR (not a brewery) -->
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="signUpUserType" id="brewRradio" value="brewR" checked>
+          <label class="form-check-label" for="brewRradio">
+            Signup as brewR
+          </label>
         </div>
+        <!-- This radio, if selected registers a user as a brewRy (a brewery) -->
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="signUpUserType" id="brewRyRadio" value="brewRy">
+          <label class="form-check-label" for="brewRyRadio">
+            Signup as brewRy
+          </label>
+        </div>
+      </form>
+      <form class="signup">
+        <div class="form-group" id="signupForm">
+          <label for="exampleInputEmail1">Email address</label>
+          <input type="email" class="form-control" id="email-input" placeholder="Email">
+        </div>
+        <div class="form-group">
+          <label for="exampleInputPassword1">Password</label>
+          <input type="password" class="form-control" id="password-input" placeholder="Password">
+        </div>
+        <div style="display: none" id="alert" class="alert alert-danger" role="alert">
+          <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+          <span class="sr-only">Error:</span> <span class="msg"></span>
+        </div>
+        <button type="submit" class="btn btn-default">Sign Up</button>
+      </form>
+      <br />
+      <p>Or log in <a href="/">here</a></p>
+
     </div>
+  </div>
 </div>


### PR DESCRIPTION
At the signup page users now must select the account type via a bootstrap radio.
The User table now has a 3rd column: `usertype`.
whenever the user logs in their `usertype` will determine whether they're routed to
`/members` or `/brewer-page`.


You'll need to drop your brewR database and make a new blank one.

Relevant Changes: 

`signup.handlebars`
**lines 13-28**
Added a form group with 2 radios for user to select their user-type when signing up for brewR.

`user.js` 
**Line 21-**
Added column `usertype` to the User table to hold the usertype selected by radio on login and signup pages.

`signup.js` 
**Line 13-**
Added property `usertype` to userData object and assigned it to the value of the radio selected by client.
**line 20-**
Added third argument `userData.usertype` to function call `signUpUser()`.
**line 27-**
Added third parameter `usertype` to `signUpUser()` function definition.
`api-routes.js` 
**line 17-**
Added `usertype: req.user.usertype` to object being send back to client.
**line 28-**
Added `usertype` property to object in `db.User.create()` call.

`signup.js`
**line 33-42**
Added `userInfo` argument to `.then()` callback.  Then redirect the page depending on the userType.
users that signed up as a brewR are sent to the `/members` page.  Users that signed up as
a brewRy are send to the `/brewer-page`.

`html-routes.js`
**line 68 and 73**
Added `isAuthenticated` argument to app.get() calls to prevent unauthorized access by nonregistered users.


