### PR TITLE
Add functionality to login and signup pages. 

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "development": {
     "username": "root",
-    "password": null,
+    "password": "+J9517mm",
     "database": "brewR",
     "host": "127.0.0.1",
     "dialect": "mysql"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1818,9 +1818,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "long": {
       "version": "4.0.0",
@@ -2258,14 +2258,11 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-<<<<<<< HEAD
     "particles.js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/particles.js/-/particles.js-2.0.0.tgz",
       "integrity": "sha1-IThsQyjWx/lngKIB6W7t/AnHNvY="
     },
-=======
->>>>>>> acbe14e035e2fd272e47bc56b9b051d5fc7b5e7f
     "passport": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.17.1",
     "express-handlebars": "^4.0.5",
     "express-session": "^1.17.1",
+    "lodash": "^4.17.19",
     "mysql": "^2.18.1",
     "mysql2": "^1.7.0",
     "particles.js": "^2.0.0",

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -40,8 +40,11 @@ $(document).ready(() => {
         }
         // If there's an error, log the error
       })
-      .catch(err => {
-        console.log(err);
-      });
+      .catch(handleLoginErr);
+  }
+
+  function handleLoginErr(err) {
+    $("#alert .msg").text((`Invalid email/password combination`));
+    $("#alert").fadeIn(500);
   }
 });

--- a/public/js/signup.js
+++ b/public/js/signup.js
@@ -42,11 +42,11 @@ $(document).ready(() => {
         }
         // If there's an error, handle it by throwing up a bootstrap alert
       })
-      .catch(handleLoginErr);
+      .catch(handleSignUpErr);
   }
 
-  function handleLoginErr(err) {
-    $("#alert .msg").text(err.responseJSON);
+  function handleSignUpErr(err) {
+    $("#alert .msg").text((`Account ${err.responseJSON.errors[0].instance.email} already exists`));
     $("#alert").fadeIn(500);
   }
 });

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -19,6 +19,10 @@
           <label for="exampleInputPassword1">Password</label>
           <input type="password" class="form-control" id="password-input" placeholder="Password">
         </div>
+        <div style="display: none" id="alert" class="alert alert-danger" role="alert">
+          <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+          <span class="sr-only">Error:</span> <span class="msg"></span>
+        </div>
         <button type="submit" class="btn btn-outline-dark btn-default">Login</button>
       </form>
       <br />


### PR DESCRIPTION
**Increased functionality of the `/signup` and `/` (login) pages:**
At `/signup` html route, when a user attempts to sign up using an account that already exist page, a small div appears and displays the error to the user.

At the root html-route, when a user attempts to login with with an bad email/password combination a small div appears and displays the error to the user.



**./public/js/signup.js**
On line 49
Adjusted code to correctly display error to user trying to sign up an account that already exists.

**./views/login.handlebars**
On lines 22-25
Added div to display errors.

**./public/login.js**
on lines 43-49
Added handleLoginErr function to display error to user when an invalid user/pw combo is used and added it to a .catch on line 43.



