### PR TITLE
Update html-routes.js

### DIFF
--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -6,16 +6,18 @@ module.exports = function(app) {
     // If the user already has an account send them to the members page
     if (req.user) {
       res.redirect("/members");
-    }
+    } else {
     res.render("login");
+    }
   });
 
   app.get("/signup", (req, res) => {
     // If the user already has an account send them to the members page
     if (req.user) {
       res.redirect("/members");
-    }
+    } else {
     res.render("signup");
+    }
   });
 
   // Here we've added our isAuthenticated middleware to this route.


### PR DESCRIPTION
Resolving Heroku Runtime error h18.  Without else statement on lines 9 and 18 app crashes when a logged in user tries to visit the "/" route because two res. calls will try to rewrite the headers after they've already been sent.